### PR TITLE
Fix/matomo consent

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -88,6 +88,20 @@ extra_css:
   
 
 extra:
+  consent:
+    title: Cookie consent
+    description: >-
+      We use analytics cookies (Matomo) to understand how visitors use the wiki
+      so we can improve it. With your consent, you help us make the documentation
+      better. You can withdraw consent at any time.
+    actions:
+      - accept
+      - reject
+      - manage
+    cookies:
+      analytics:
+        name: Matomo
+        checked: false
   social:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/de-nbi/

--- a/config.yml
+++ b/config.yml
@@ -118,6 +118,7 @@ extra:
   footer_links: 
   - { name: "Policies", href: "https://cloud.denbi.de/about/policies/" }
   - { name: "Imprint", href: "https://cloud.denbi.de/about/imprint/" }
+  - { name: "Cookie Consent", href: "#__consent", new_tab: false }
   cloud_portal_wiki_link: !ENV [CLOUD_PORTAL_WIKI_LINK, 'https://cloud.denbi.de/wiki/']
 
 nav:

--- a/wiki/matomo.js
+++ b/wiki/matomo.js
@@ -1,13 +1,26 @@
-var _paq = window._paq || [];
-/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+var _paq = window._paq = window._paq || [];
+_paq.push(['requireConsent']);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
 (function() {
-    var u="//cloud.denbi.de/matomo/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '2']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  var u = "https://piwik.cebitec.uni-bielefeld.de/";
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', '40']);
+  var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+  g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
 })();
 
-
+// Material writes consent to localStorage under key "__consent"
+function applyMatomoConsent() {
+  try {
+    var c = JSON.parse(localStorage.getItem('__consent') || '{}');
+    if (c.analytics === 'accepted') {
+      _paq.push(['setConsentGiven']);
+      _paq.push(['setCookieConsentGiven']);
+    } else {
+      _paq.push(['forgetConsentGiven']);
+    }
+  } catch (e) {}
+}
+applyMatomoConsent();
+window.addEventListener('storage', applyMatomoConsent); // reflect changes made in other tabs

--- a/wiki/overrides/main.html
+++ b/wiki/overrides/main.html
@@ -7,7 +7,8 @@
         <div class="md-grid">
             <div style="margin: auto; text-align: center; padding: 2rem;">
             {% for link in config.extra.footer_links %}
-            <a href="{{ link.href }}" rel="noopener noreferrer" target="_blank">{{ link.name }}</a>{% if not loop.last %} | {% endif %}
+              <a href="{{ link.href }}"
+              {% if link.new_tab | default(true) %}rel="noopener noreferrer" target="_blank"{% endif %}>{{ link.name }}</a>{% if not loop.last %} | {% endif %}
             {% endfor %}
             </div>
         </div>


### PR DESCRIPTION
@dweinholz added script for matomo and cookie-banner. 
You can test locally by running the config.yml settings dockerized as described in readme:

```
docker run -it -v "$(pwd):/srv_root/docs"  -p "8000:8000" --env ENABLED_HTMLPROOFER=False --entrypoint="mkdocs" quay.io/denbicloud/mkdocswebhook:staging serve -f /srv_root/docs/config.yml   --dev-addr 0.0.0.0:8000 
```

Try to fulfill the following points before the Pull Request is merged:
- [ ] Please create your prs against the dev branch
- [ ] Please WAIT for the tests to finish.
- [ ] All tests have been successfully completed.
- [ ] When adding a new documentation or tutorial, make sure that the markdown is linked in the config.yml
